### PR TITLE
Massively rework test_config.

### DIFF
--- a/puckfetcher/subscription.py
+++ b/puckfetcher/subscription.py
@@ -422,6 +422,15 @@ class Subscription(object):
 
         return _helper()
 
+    def as_config_yaml(self):
+        """Return self as config file YAML."""
+
+        return {"url": self.original_url,
+                "name": self.name,
+                "backlog_limit": self.backlog_limit,
+                "directory": self.directory}
+
+
     # "Private" class functions (messy internals).
     def _feedparser_parse_with_options(self):
         """

--- a/puckfetcher/test/test_config.py
+++ b/puckfetcher/test/test_config.py
@@ -1,222 +1,172 @@
-import copy
-import logging
+"""Tests for the config module."""
 import os
-import shutil
-import tempfile
 
+import pytest
 import umsgpack
 import yaml
 
 import puckfetcher.config as PC
 import puckfetcher.subscription as PS
 
+def test_default_config_construct(default_config, default_conf_file, default_cache_file):
+    """Test config with no arguments assigns the right file vars."""
+    assert default_config.config_file == default_conf_file
+    assert default_config.cache_file == default_cache_file
 
-class TestConfig:
-    @classmethod
-    def setup_class(cls):
+def test_load_only_cache(default_config, default_cache_file, subscriptions):
+    """Subscriptions list should be empty if there are cached subs but no subs in settings."""
+    write_subs_to_file(subs=subscriptions, out_file=default_cache_file, write_type="cache")
 
-        # Mock XDG spec dirs to ensure we do the correct thing, and also that we don't put files in
-        # strange places during testing.
-        cls.old_environ = dict(os.environ)
+    default_config.load_state()
 
-        cls.default_config_dir = os.path.join(tempfile.mkdtemp(), "puckfetcher")
-        cls.default_config_file = os.path.join(cls.default_config_dir, "config.yaml")
+    assert default_config.cached_subscriptions == subscriptions
+    assert default_config.subscriptions == []
 
-        cls.default_cache_dir = os.path.join(tempfile.mkdtemp(), "puckfetcher")
+def test_load_only_user_settings_works(default_config, default_conf_file, subscriptions):
+    """Test that settings can be loaded correctly from just the user settings."""
+    write_subs_to_file(subs=subscriptions, out_file=default_conf_file, write_type="config")
 
-        cls.default_log_file = os.path.join(cls.default_cache_dir, "puckfetcher.log")
-        logging.getLogger("root")
+    default_config.load_state()
 
-        cls.default_cache_file = os.path.join(cls.default_cache_dir, "puckcache")
+    assert default_config.cached_subscriptions == []
+    assert default_config.subscriptions == subscriptions
 
-        cls.default_data_dir = os.path.join(tempfile.mkdtemp(), "puckfetcher")
+def test_non_config_subs_ignore(default_config, default_conf_file, default_cache_file,
+                                subscriptions):
+    """Subscriptions in cache but not config shouldn't be in subscriptions list."""
+    write_subs_to_file(subs=subscriptions, out_file=default_cache_file, write_type="cache")
+    write_subs_to_file(subs=subscriptions[0:1], out_file=default_conf_file, write_type="config")
 
-        cls.files = [cls.default_config_file, cls.default_log_file, cls.default_cache_file]
+    default_config.load_state()
 
-        cls.subscriptions = []
-        for i in range(0, 3):
-            name = "test" + str(i)
-            url = "testurl" + str(i)
-            directory = os.path.join(cls.default_data_dir, "dir" + str(i))
+    assert default_config.cached_subscriptions == subscriptions
+    assert default_config.subscriptions == subscriptions[0:1]
 
-            sub = PS.Subscription(name=name, url=url, directory=directory)
+def test_subscriptions_matching_works(default_config, default_conf_file, default_cache_file,
+                                      subscriptions):
+    """Subscriptions in cache should be matched to subscriptions in config by name or url."""
+    write_subs_to_file(subs=subscriptions, out_file=default_conf_file, write_type="config")
 
-            sub.download_backlog = True
-            sub.backlog_limit = 1
-            sub.use_title_as_filename = False
+    test_urls = ["bababba", "aaaaaaa", "ccccccc"]
+    test_names = ["ffffff", "ggggg", "hhhhhh"]
+    test_nums = [23, 555, 66666]
 
-            cls.subscriptions.append(sub)
+    # Change names and urls in subscriptions. They should be able to be matched to config
+    # subscriptions.
+    for i, sub in enumerate(subscriptions):
+        sub.feed_state.latest_entry_number = test_nums[i]
 
-    @classmethod
-    def teardown_class(cls):
-        """Perform test cleanup."""
-        shutil.rmtree(cls.default_config_dir)
-        shutil.rmtree(cls.default_cache_dir)
-        shutil.rmtree(cls.default_data_dir)
+        if i % 2 == 0:
+            sub.original_url = test_urls[i]
+            sub.url = test_urls[i]
+        else:
+            sub.name = test_names[i]
 
-    # pylint: disable=invalid-name, no-self-use
-    def test_default_config_assigns_files(self):
-        """Test config with arguments assigns the right file vars."""
-        config = _create_test_config()
+        subscriptions[i] = sub
 
-        assert config.config_file == TestConfig.default_config_file
-        assert config.cache_file == TestConfig.default_cache_file
+    write_subs_to_file(subs=subscriptions, out_file=default_cache_file, write_type="cache")
 
-    # pylint: disable=invalid-name, no-self-use
-    def test_load_only_cache_loads_nothing(self):
-        """If there are only subs in the cache, none in settings, discard them."""
-        config = _create_test_config()
+    default_config.load_state()
 
-        write_msgpack_subs_to_file()
+    # The url and name the user gave should be prioritized and the cached url/name discarded.
+    for i, sub in enumerate(default_config.subscriptions):
+        if i % 2 == 0:
+            assert sub.original_url != test_urls[i]
+            assert sub.url != test_urls[i]
+        else:
+            assert sub.name != test_names[i]
 
-        config.load_state()
+        assert sub.feed_state.latest_entry_number == test_nums[i]
 
-        assert config.cached_subscriptions == TestConfig.subscriptions
-        assert config.subscriptions == []
 
-    # pylint: disable=invalid-name, no-self-use
-    def test_load_only_user_settings_works(self):
-        """Test that settings can be loaded correctly from just the user settings."""
-        config = _create_test_config()
+def test_save_works(default_config, default_cache_file, subscriptions):
+    """Test that we can save subscriptions correctly."""
+    default_config.subscriptions = subscriptions
 
-        write_yaml_subs_to_file()
+    default_config.save_cache()
 
-        config.load_state()
+    with open(default_cache_file, "rb") as stream:
+        contents = stream.read()
+        subs = [PS.Subscription.decode_subscription(sub) for sub in umsgpack.unpackb(contents)]
 
-        assert config.cached_subscriptions == []
-        assert config.subscriptions == TestConfig.subscriptions
-
-    # pylint: disable=invalid-name, no-self-use
-    def test_non_config_subs_ignore(self):
-        """Subscriptions in cache but not config shouldn't be in subscriptions list."""
-        config = _create_test_config()
-
-        write_msgpack_subs_to_file()
-        write_yaml_subs_to_file(subs=[TestConfig.subscriptions[0]])
-
-        config.load_state()
-
-        assert config.cached_subscriptions == TestConfig.subscriptions
-        assert config.subscriptions == [TestConfig.subscriptions[0]]
-
-    # pylint: disable=invalid-name, no-self-use
-    def test_subscriptions_matching_works(self):
-        """Subscriptions in cache should be matched to subscriptions in config by name or url."""
-        config = _create_test_config()
-
-        subs = _deep_copy_subs()
-
-        write_yaml_subs_to_file(subs=subs)
-
-        test_urls = ["bababba", "aaaaaaa", "ccccccc"]
-        test_names = ["ffffff", "ggggg", "hhhhhh"]
-        test_nums = [23, 555, 66666]
-
-        # Change names and urls in subscriptions. They should be able to be matched to config
-        # subscriptions.
-        for i, sub in enumerate(subs):
-            sub.feed_state.latest_entry_number = test_nums[i]
-
-            if i % 2 == 0:
-                sub.original_url = test_urls[i]
-                sub.url = test_urls[i]
-            else:
-                sub.name = test_names[i]
-
-            subs[i] = sub
-
-        write_msgpack_subs_to_file(subs=subs)
-
-        config.load_state()
-
-        # The url and name the user gave should be prioritized and the cache url/name discarded.
-        for i, sub in enumerate(config.subscriptions):
-            if i % 2 == 0:
-                assert sub.original_url != test_urls[i]
-                assert sub.url != test_urls[i]
-            else:
-                assert sub.name != test_names[i]
-
-            assert sub.feed_state.latest_entry_number == test_nums[i]
-
-    # pylint: disable=no-self-use
-    def test_save_works(self):
-        """Test that we can save subscriptions correctly."""
-        config = _create_test_config()
-
-        config.subscriptions = TestConfig.subscriptions
-
-        config.save_cache()
-
-        with open(TestConfig.default_cache_file, "rb") as fff:
-            contents = fff.read()
-            subs = [PS.Subscription.decode_subscription(sub) for sub in umsgpack.unpackb(contents)]
-
-        assert config.subscriptions == subs
+    assert default_config.subscriptions == subs
 
 
 # Helpers.
-def _deep_copy_subs():
-    return [copy.deepcopy(sub) for sub in TestConfig.subscriptions]
+def write_subs_to_file(subs, out_file, write_type):
+    """Write subs to a file with the selected type."""
+
+    if write_type == "cache":
+        encoded_subs = [PS.Subscription.encode_subscription(sub) for sub in subs]
+        data = umsgpack.packb(encoded_subs)
+        with open(out_file, "wb") as stream:
+            stream.write(data)
+
+    elif write_type == "config":
+        data = {}
+        data["subscriptions"] = [sub.as_config_yaml() for sub in subs]
+        with open(out_file, "w") as stream:
+            yaml.dump(data, stream)
+
+    else:
+        print("Type unsupported!")
+        assert False
 
 
-def _create_test_config():
-    for created_file in TestConfig.files:
-        if os.path.isfile(created_file):
-            os.remove(created_file)
+# Fixtures.
+@pytest.fixture(scope="function")
+def config_dirs(tmpdir):
+    """Generate XDG dirs and vars."""
+    config_dir = str(tmpdir.mkdir("config"))
+    cache_dir = str(tmpdir.mkdir("cache"))
+    data_dir = str(tmpdir.mkdir("data"))
 
-    return PC.Config(config_dir=TestConfig.default_config_dir,
-                     cache_dir=TestConfig.default_cache_dir,
-                     data_dir=TestConfig.default_data_dir)
+    os.environ["XDG_CONFIG_HOME"] = config_dir
+    os.environ["XDG_CACHE_DIR"] = cache_dir
+    os.environ["XDG_DATA_DIR"] = data_dir
 
-
-def _ensure_file(out_file, default):
-    # I don't like this, but it didn't seem like I could set keyword arguments to default to
-    # class variables.
-    if out_file is None:
-        out_file = default
-
-    directory, _ = os.path.split(out_file)
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    return out_file
+    return (config_dir, cache_dir, data_dir)
 
 
-def write_msgpack_subs_to_file(out_file=None, subs=None):
-    """Write subs to a file through msgpack."""
-
-    out_file = _ensure_file(out_file, TestConfig.default_cache_file)
-
-    if subs is None:
-        subs = TestConfig.subscriptions
-
-    encoded_subs = [PS.Subscription.encode_subscription(sub) for sub in subs]
-
-    with open(out_file, "wb") as stream:
-        packed = umsgpack.packb(encoded_subs)
-        stream.write(packed)
+@pytest.fixture(scope="function")
+def default_conf_file(config_dirs):
+    """Provide name of default config file config object should use."""
+    (config_dir, _, _) = config_dirs
+    return os.path.join(config_dir, "config.yaml")
 
 
-def sub_to_user_yaml(sub):
-    """Convert a subscription to YAML we expect to find in the users's config file."""
-    # pylint: disable=protected-access
-    return {"url": sub.original_url,
-            "name": sub.name,
-            "backlog_limit": sub.backlog_limit,
-            "download_backlog": sub.download_backlog,
-            "directory": sub.directory}
+@pytest.fixture(scope="function")
+def default_cache_file(config_dirs):
+    """Provide name of default cache file config object should use."""
+    (_, cache_dir, _) = config_dirs
+    return os.path.join(cache_dir, "puckcache")
 
 
-def write_yaml_subs_to_file(out_file=None, subs=None):
-    """Write subscriptions in YAML to the config file."""
-    out_file = _ensure_file(out_file, TestConfig.default_config_file)
+@pytest.fixture(scope="function")
+def subscriptions(tmpdir):
+    """Generate subscriptions for config testing."""
+    sub_dir = str(tmpdir.mkdir("foo"))
 
-    data = {}
-    if subs is None:
-        subs = TestConfig.subscriptions
+    subs = []
+    for i in range(0, 3):
+        name = "test" + str(i)
+        url = "testurl" + str(i)
+        directory = os.path.join(sub_dir, "dir" + str(i))
 
-    data["subscriptions"] = [sub_to_user_yaml(sub) for sub in subs]
+        sub = PS.Subscription(name=name, url=url, directory=directory)
 
-    with open(out_file, "w") as stream:
-        yaml.dump(data, stream)
+        sub.download_backlog = True
+        sub.backlog_limit = 1
+        sub.use_title_as_filename = False
+
+        subs.append(sub)
+
+    return subs
+
+
+@pytest.fixture(scope="function")
+def default_config(config_dirs):
+    """Create test config with temporary test dirs."""
+    (config_dir, cache_dir, data_dir) = config_dirs
+
+    return PC.Config(config_dir=config_dir, cache_dir=cache_dir, data_dir=data_dir)

--- a/puckfetcher/test/test_config.py
+++ b/puckfetcher/test/test_config.py
@@ -108,10 +108,6 @@ def write_subs_to_file(subs, out_file, write_type):
         with open(out_file, "w") as stream:
             yaml.dump(data, stream)
 
-    else:
-        print("Type unsupported!")
-        assert False
-
 
 # Fixtures.
 @pytest.fixture(scope="function")

--- a/puckfetcher/test/test_subscription.py
+++ b/puckfetcher/test/test_subscription.py
@@ -1,13 +1,13 @@
 """Tests for the subscription module."""
-import shutil
 import os
-import tempfile
+import random
+import string
 
-# pylint: disable=import-error
-import pytest as PT
+import pytest
 
-import puckfetcher.subscription as SUB
+import puckfetcher.config as PE
 import puckfetcher.error as PE
+import puckfetcher.subscription as SUB
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -22,164 +22,130 @@ HTTP_404_ADDRESS = RSS_TEST_HOST + "404"
 HTTP_410_ADDRESS = RSS_TEST_HOST + "410"
 
 
-# TODO this needs reworking to split out of one class without losing the setup/teardown
-class TestSubscription(object):
-    """Test that a subscription has correct behavior."""
-    @classmethod
-    def setup_class(cls):
-        """Perform stuff that should happen before all tests."""
-        cls.xdg_config_home = tempfile.mkdtemp()
-        cls.old_xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "")
-        os.environ["XDG_CONFIG_HOME"] = cls.xdg_config_home
+def test_empty_url_cons(strdir):
+    """
+    Constructing a subscription with an empty URL should throw a MalformedSubscriptionError.
+    """
+    with pytest.raises(PE.MalformedSubscriptionError) as exception:
+        SUB.Subscription(url="", name="emptyConstruction", directory=strdir)
 
-        cls.xdg_cache_home = tempfile.mkdtemp()
-        cls.old_xdg_cache_home = os.environ.get("XDG_CACHE_HOME", "")
-        os.environ["XDG_CACHE_HOME"] = cls.xdg_cache_home
-
-        cls.xdg_data_home = tempfile.mkdtemp()
-        cls.old_xdg_data_home = os.environ.get("XDG_DATA_HOME", "")
-        os.environ["XDG_DATA_HOME"] = cls.xdg_data_home
-
-        cls.d = os.path.join(cls.xdg_data_home, "tmp")
-
-    @classmethod
-    def teardown_class(cls):
-        """Perform stuff that should happen after all tests."""
-        os.environ["XDG_CONFIG_HOME"] = cls.old_xdg_config_home
-        os.environ["XDG_CACHE_HOME"] = cls.old_xdg_cache_home
-        os.environ["XDG_DATA_HOME"] = cls.old_xdg_data_home
-
-        shutil.rmtree(cls.xdg_config_home)
-        shutil.rmtree(cls.xdg_cache_home)
-        shutil.rmtree(cls.xdg_data_home)
-
-    # Pylint apparently objects to test_method_name and method_name_T. The fuck?
-    # pylint: disable=invalid-name,no-self-use
-    def test_empty_url_construction_errors(self):
-        """
-        Constructing a subscription with a URL that is empty should throw a
-        MalformedSubscriptionError.
-        """
-        with PT.raises(PE.MalformedSubscriptionError) as exception:
-            SUB.Subscription(url="", name="emptyConstruction", directory=TestSubscription.d)
-
-        assert exception.value.desc == "No URL provided."
-
-    # Pylint apparently objects to test_method_name and method_name_T. The fuck?
-    # pylint: disable=invalid-name,no-self-use
-    def test_none_url_construction_errors(self):
-        """
-        Constructing a subscription with a URL that is None should throw a
-        MalformedSubscriptionError.
-        """
-        with PT.raises(PE.MalformedSubscriptionError) as exception:
-            SUB.Subscription(name="noneConstruction", directory=TestSubscription.d)
-
-        assert exception.value.desc == "No URL provided."
-
-    # Pylint apparently objects to test_method_name and method_name_T. The fuck?
-    # pylint: disable=invalid-name
-    def test_empty_name_construction_errors(self):
-        """
-        Constructing a subscription with a name that is empty should throw a
-        MalformedSubscriptionError.
-        """
-        with PT.raises(PE.MalformedSubscriptionError) as e:
-            SUB.Subscription(url="foo", name="", directory=TestSubscription.d)
-
-        assert e.value.desc == "No name provided."
-
-    # Pylint apparently objects to test_method_name and method_name_T. The fuck?
-    # pylint: disable=invalid-name
-    def test_none_name_construction_errors(self):
-        """
-        Constructing a subscription with a name that is None should throw a
-        MalformedSubscriptionError.
-        """
-        with PT.raises(PE.MalformedSubscriptionError) as e:
-            SUB.Subscription(url="foo", name=None, directory=TestSubscription.d)
-
-        assert e.value.desc == "No name provided."
-
-    # Pylint apparently objects to test_method_name and method_name_T. The fuck?
-    # pylint: disable=invalid-name
-    def test_get_feed_helper_fails_after_max(self):
-        """If we try more than MAX_RECURSIVE_ATTEMPTS to retrieve a URL, we should fail."""
-        sub = SUB.Subscription(url=HTTP_302_ADDRESS, name="tooManyAttemptsTest",
-                               directory=TestSubscription.d)
-
-        # TODO tests need to be rewritten to check log output or something.
-        sub.get_feed(attempt_count=SUB.MAX_RECURSIVE_ATTEMPTS+1)
-
-        assert sub.feed_state.feed == {}
-        assert sub.feed_state.entries == []
-
-    def test_valid_temporary_redirect_succeeds(self):
-        """
-        If we are redirected temporarily to a valid RSS feed, we should successfully parse that
-        feed and not change our url. The originally provided URL should be unchanged.
-        """
-        _test_url_helper(HTTP_302_ADDRESS, "302Test", HTTP_302_ADDRESS, HTTP_302_ADDRESS)
-
-    def test_valid_permanent_redirect_succeeds(self):
-        """
-        If we are redirected permanently to a valid RSS feed, we should successfully parse that
-        feed and change our url.  The originally provided URL should be unchanged
-        """
-        _test_url_helper(HTTP_301_ADDRESS, "301Test", RSS_ADDRESS, HTTP_301_ADDRESS)
-
-    def test_not_found_fails(self):
-        """If the URL is Not Found, we should not change the saved URL."""
-        _test_url_helper(HTTP_404_ADDRESS, "404Test", HTTP_404_ADDRESS, HTTP_404_ADDRESS)
-
-    def test_gone_fails(self):
-        """If the URL is Gone, the current url should be set to None, and we should return None."""
-
-        sub = SUB.Subscription(url=HTTP_410_ADDRESS, name="410Test", directory=TestSubscription.d)
-
-        sub.use_backlog = True
-        sub.backlog_limit = 1
-        sub.use_title_as_filename = False
-
-        sub.get_feed()
-
-        assert sub.url is None
-        assert sub.original_url == HTTP_410_ADDRESS
-
-    # TODO attempt to make tests that are less fragile/dependent on my website configuration/files.
-    def test_attempt_download_backlog(self):
-        """Should download full backlog by default."""
-        sub = SUB.Subscription(url=RSS_ADDRESS, name="testfeed", directory=TestSubscription.d)
-
-        sub.use_backlog = True
-        sub.backlog_limit = None
-        sub.use_title_as_filename = False
-
-        sub.attempt_update()
-
-        assert len(sub.feed_state.entries) == 10
-        for i in range(1, 9):
-            _check_hi_contents(i, sub.directory)
-
-    def test_attempt_download_partial_backlog(self):
-        """Should download partial backlog if limit is specified."""
-        sub = SUB.Subscription(url=RSS_ADDRESS, name="testfeed", backlog_limit=5,
-                               directory=TestSubscription.d)
-
-        # TODO find a cleaner way to set these.
-        # Maybe Subscription should handle these attributes missing better?
-        # Maybe have a cleaner way to hack them in in tests?
-        sub.use_backlog = True
-        sub.use_title_as_filename = False
-        sub.attempt_update()
-
-        assert len(sub.feed_state.entries) == 10
-        for i in range(0, 4):
-            _check_hi_contents(i, sub.directory)
+    assert exception.value.desc == "No URL provided."
 
 
-def _test_url_helper(given, name, expected_current, expected_original):
-    sub = SUB.Subscription(url=given, name=name, directory=TestSubscription.d)
+def test_none_url_cons(strdir):
+    """
+    Constructing a subscription with a URL that is None should throw a MalformedSubscriptionError.
+    """
+    with pytest.raises(PE.MalformedSubscriptionError) as exception:
+        SUB.Subscription(name="noneConstruction", directory=strdir)
+
+    assert exception.value.desc == "No URL provided."
+
+
+def test_empty_name_cons(strdir):
+    """
+    Constructing a subscription with an empty name should throw a MalformedSubscriptionError.
+    """
+    with pytest.raises(PE.MalformedSubscriptionError) as exception:
+        SUB.Subscription(url="foo", name="", directory=strdir)
+
+    assert exception.value.desc == "No name provided."
+
+
+def test_none_name_cons(strdir):
+    """
+    Constructing a subscription with a name that is None should throw a MalformedSubscriptionError.
+    """
+    with pytest.raises(PE.MalformedSubscriptionError) as exception:
+        SUB.Subscription(url="foo", name=None, directory=strdir)
+
+    assert exception.value.desc == "No name provided."
+
+
+def test_get_feed_max(strdir, salt):
+    """If we try more than MAX_RECURSIVE_ATTEMPTS to retrieve a URL, we should fail."""
+    sub = SUB.Subscription(url=HTTP_302_ADDRESS, name="tooManyAttemptsTest" + salt,
+                           directory=strdir)
+
+    # TODO tests need to be rewritten to check log output or something.
+    sub.get_feed(attempt_count=SUB.MAX_RECURSIVE_ATTEMPTS+1)
+
+    assert sub.feed_state.feed == {}
+    assert sub.feed_state.entries == []
+
+
+def test_temporary_redirect(strdir, salt):
+    """
+    If we are redirected temporarily to a valid RSS feed, we should successfully parse that
+    feed and not change our url. The originally provided URL should be unchanged.
+    """
+    _test_url_helper(strdir, HTTP_302_ADDRESS, "302Test" + salt, HTTP_302_ADDRESS,
+                     HTTP_302_ADDRESS)
+
+
+def test_permanent_redirect(strdir, salt):
+    """
+    If we are redirected permanently to a valid RSS feed, we should successfully parse that
+    feed and change our url. The originally provided URL should be unchanged.
+    """
+    _test_url_helper(strdir, HTTP_301_ADDRESS, "301Test" + salt, RSS_ADDRESS, HTTP_301_ADDRESS)
+
+
+def test_not_found_fails(strdir):
+    """If the URL is Not Found, we should not change the saved URL."""
+    _test_url_helper(strdir, HTTP_404_ADDRESS, "404Test", HTTP_404_ADDRESS, HTTP_404_ADDRESS)
+
+
+def test_gone_fails(strdir):
+    """If the URL is Gone, the current url should be set to None, and we should return None."""
+
+    sub = SUB.Subscription(url=HTTP_410_ADDRESS, name="410Test", directory=strdir)
+
+    sub.use_backlog = True
+    sub.backlog_limit = 1
+    sub.use_title_as_filename = False
+
+    sub.get_feed()
+
+    assert sub.url is None
+    assert sub.original_url == HTTP_410_ADDRESS
+
+
+# TODO attempt to make tests that are less fragile/dependent on my website configuration/files.
+def test_attempt_download_backlog(strdir):
+    """Should download full backlog by default."""
+    sub = SUB.Subscription(url=RSS_ADDRESS, name="testfeed", directory=strdir)
+
+    sub.use_backlog = True
+    sub.backlog_limit = None
+    sub.use_title_as_filename = False
+
+    sub.attempt_update()
+
+    assert len(sub.feed_state.entries) == 10
+    for i in range(1, 9):
+        _check_hi_contents(i, sub.directory)
+
+
+def test_attempt_download_partial_backlog(strdir):
+    """Should download partial backlog if limit is specified."""
+    sub = SUB.Subscription(url=RSS_ADDRESS, name="testfeed", backlog_limit=5, directory=strdir)
+
+    # TODO find a cleaner way to set these.
+    # Maybe Subscription should handle these attributes missing better?
+    # Maybe have a cleaner way to hack them in in tests?
+    sub.use_backlog = True
+    sub.use_title_as_filename = False
+    sub.attempt_update()
+
+    assert len(sub.feed_state.entries) == 10
+    for i in range(0, 4):
+        _check_hi_contents(i, sub.directory)
+
+
+# Helpers.
+def _test_url_helper(strdir, given, name, expected_current, expected_original):
+    sub = SUB.Subscription(url=given, name=name, directory=strdir)
     sub.get_feed()
 
     assert sub.url == expected_current
@@ -191,3 +157,16 @@ def _check_hi_contents(filename_num, directory):
     with open(file_path, "r") as enclosure:
         data = enclosure.read().replace('\n', '')
         assert data == "hi"
+
+
+# Fixtures.
+@pytest.fixture(scope="function")
+def strdir(tmpdir):
+    """Create temp directory, in string format."""
+    return str(tmpdir.mkdir("foo"))
+
+
+@pytest.fixture(scope="function")
+def salt():
+    """Provide random string to avoid my rate-limiting."""
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(5))

--- a/puckfetcher/util.py
+++ b/puckfetcher/util.py
@@ -19,7 +19,7 @@ LAST_CALLED = {}
 # I'm unsure if this the best way to do this.
 # TODO don't support andrewmichaud.com, we should have proper local file support eventually, and
 # run tests with that.
-RATELIMIT_DOMAIN_WHITELIST = ["localhost", "www.andrewmichaud.com"]
+RATELIMIT_DOMAIN_WHITELIST = ["andrewmichaud.com"]
 
 
 def generate_downloader(headers, args):
@@ -134,7 +134,7 @@ def rate_limited(domain, max_per_hour, *args):
             LOG.debug("Rate limiter last called for '%s' at %s.", key, last_called)
             LOG.debug("Remaining cooldown time for '%s' is %s.", key, remaining)
 
-            if domain not in RATELIMIT_DOMAIN_WHITELIST and remaining > 0 and last_called > 0.0:
+            if not skip_rate_limiting(domain) and remaining > 0 and last_called > 0.0:
                 LOG.info("Self-enforced rate limit hit, sleeping %s seconds.", remaining)
                 time.sleep(remaining)
 
@@ -145,3 +145,13 @@ def rate_limited(domain, max_per_hour, *args):
 
         return _rate_limited_function
     return _decorate
+
+def skip_rate_limiting(domain):
+    """Provide a hack to skip rate limiting during tests, for certain domains."""
+    res = False
+    for sub_url in RATELIMIT_DOMAIN_WHITELIST:
+        if sub_url in domain:
+            res = True
+            break
+
+    return res


### PR DESCRIPTION
Move user YAML generation to subscription object.
Don't have a big ugly class.
Use pytest fixtures to provide test objects.
Cut some duplicate code.