### PR TITLE
Fix sub update failing due to missing directory.

### DIFF
--- a/puckfetcher/util.py
+++ b/puckfetcher/util.py
@@ -26,12 +26,6 @@ def generate_downloader(headers, args):
     """Create function to download with rate limiting and text progress."""
 
     def _downloader(url, dest, overwrite=True):
-        # If there is a file with the name we intend to save to, assume the podcast has
-        # been downloaded already.
-        if os.path.isfile(dest) and not overwrite:
-            LOG.info("File %s exists, not overwriting, assuming downloaded.", dest)
-            print("File exists. Assuming already downloaded and skipping.")
-            return
 
         domain = urlparse(url).netloc
         if domain == "":
@@ -39,6 +33,18 @@ def generate_downloader(headers, args):
 
         @rate_limited(domain, 30, args)
         def _rate_limited_download():
+            # If there is a file with the name we intend to save to, assume the podcast has
+            # been downloaded already.
+            if os.path.isfile(dest) and not overwrite:
+                LOG.info("File %s exists, not overwriting, assuming downloaded.", dest)
+                print("File exists. Assuming already downloaded and skipping.")
+                return
+
+            # Create parent directory of file, and its parents, if they don't exist.
+            parent = os.path.dirname(dest)
+            if not os.path.exists(parent):
+                os.makedirs(parent)
+
             response = requests.get(url, headers=headers, stream=True)
             LOG.info("Actually downloading from %s", url)
             LOG.info("Trying to save to %s", dest)


### PR DESCRIPTION
When downloading a file, create parent + full path of file, if they
don't already exist.