### PR TITLE
Improve add to backlog interface.

### DIFF
--- a/puckfetcher/__main__.py
+++ b/puckfetcher/__main__.py
@@ -104,20 +104,18 @@ def _handle_command(command, config, command_options, log):
         sub_index = _choose_sub(config)
         config.download_queue(sub_index)
 
+    # TODO this needs work.
     elif command == Config.Command.enqueue.name:
-        entry_nums = _sub_list_command_wrapper(config, command, log)
-        if entry_nums is not None:
-            config.enqueue(sub_index, entry_nums)
+        (sub_index, entry_nums) = _sub_list_command_wrapper(config, command, log)
+        config.enqueue(sub_index, entry_nums)
 
     elif command == Config.Command.mark.name:
-        entry_nums = _sub_list_command_wrapper(config, command, log)
-        if entry_nums is not None:
-            config.mark(sub_index, entry_nums)
+        (sub_index, entry_nums) = _sub_list_command_wrapper(config, command, log)
+        config.mark(sub_index, entry_nums)
 
     elif command == Config.Command.unmark.name:
-        entry_nums = _sub_list_command_wrapper(config, command, log)
-        if entry_nums is not None:
-            config.unmark(sub_index, entry_nums)
+        (sub_index, entry_nums) = _sub_list_command_wrapper(config, command, log)
+        config.unmark(sub_index, entry_nums)
 
     else:
         log.error("Unknown command. Allowed commands are:")
@@ -129,7 +127,7 @@ def _sub_list_command_wrapper(config, command, log):
     sub_index = _choose_sub(config)
     config.details(sub_index)
     log.info("COMMAND - {}".format(command))
-    return _choose_entries()
+    return (sub_index, _choose_entries())
 
 def _choose_sub(config):
     sub_names = config.get_subs()

--- a/puckfetcher/error.py
+++ b/puckfetcher/error.py
@@ -14,6 +14,14 @@ class PuckError(Exception):
         super(PuckError, self).__init__()
         self.desc = desc
 
+class BadCommandError(PuckError):
+    """
+    Exception raised when a command is given bad arguments.
+    Attributes:
+        desc -- short message describing error.
+    """
+    def __init__(self, desc):
+        super(BadCommandError, self).__init__(desc)
 
 class MalformedConfigError(PuckError):
     """


### PR DESCRIPTION
Implicitly unmark as downloaded when manually adding to download queue.
Previously you'd have to do it manually, and that's bad UI.
Wrap up validations a bit in config commands, and provide a new error
for bad command args.
Don't validate in main - let config do it.
Fix some places we were exposing zero-based-indices.
UI gets 1-based indices only (otherwise there's no point having both.)
Bounds check in subscription download, just in case.
Fix details - it was showing items in the state dictionary but not
downloaded as downloaded.
Fix get_feed having a redundant internal helper method for some absurd
reason (I don't know why I originally wrote that).